### PR TITLE
Fix Lyn_Extractor instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RGH-PC-Audio
 Python scripts designed for extracting and reimporting custom audio for RGH.
 
-# LyN_Extract
-Usage: Python Lyn_Extract.py input.sns output.wav
+# Lyn_Extractor
+Usage: Python Lyn_Extractor.py input.sns output.wav
 
 # LyN_Reimport
 Usage: Python Lyn_Reimport.py input.sns input.wav output.sns


### PR DESCRIPTION
## Summary
- fix heading and usage example for the extractor script

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685666450d74832085e42c158727e834